### PR TITLE
Add . to the end of docker build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can also use Docker:
 ```sh
 > git clone https://github.com/csg-tokyo/typelevelLR
 > cd typelevelLR
-> docker build -t csg-tokyo/typelevellr:latest
+> docker build -t csg-tokyo/typelevellr:latest .
 > docker run -v $(pwd):/workdir -it csg-tokyo/typelevellr:latest
 ```
 


### PR DESCRIPTION
to prevent the error below (minor fix).

```
Matts966:~/typelevelLR$ docker build -t csg-tokyo/typelevellr:latest
"docker build" requires exactly 1 argument.
See 'docker build --help'.

Usage:  docker build [OPTIONS] PATH | URL | -

Build an image from a Dockerfile
```