### PR TITLE
Omit git clone in Dockerfile as we already clone it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ cabal.sandbox.config
 cabal.project.local
 .HTF/
 .ghc.environment.*
+bin/
 
 ###############################################################################
 # C++

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,3 @@
-
 FROM haskell:8.0.2
-RUN git clone https://github.com/csg-tokyo/typelevelLR.git
-RUN cd typelevelLR && stack install
 WORKDIR /workdir
-ENTRYPOINT ["typelevelLR"]
+ENTRYPOINT [ "./docker-entrypoint.sh" ]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,5 +8,5 @@ if [[ -f "$FILE" ]]; then
 fi
 
 echo "building typelevelLR..."
-stack install && cp $(which typelevelLR) ./bin/
+stack install && mkdir -p bin  && cp $(which typelevelLR) ./bin/
 /bin/bash

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+FILE=./bin/typelevelLR
+if [[ -f "$FILE" ]]; then
+  echo "$FILE exists, use build cache."
+  mv ./bin/typelevelLR /usr/local/bin
+  /bin/bash
+  exit 0
+fi
+
+echo "building typelevelLR..."
+stack install && cp $(which typelevelLR) ./bin/
+/bin/bash


### PR DESCRIPTION
**Changes**
- Omit `git clone` in Dockerfile
- Add docker-entrypoint.sh
  - to check if there is already binary file
  - use it if there is
  - build it if there is not
- Update .gitignore to ignore built binary

It is appreciated to get your feedback.
Thank you!
