### PR TITLE
Allow derivation which starts with "e" character

### DIFF
--- a/src/SyntaxParser.hs
+++ b/src/SyntaxParser.hs
@@ -56,8 +56,8 @@ parseRule = do
   return (Rule name lhs rhs)
 
 parseDerivation :: (Stream s m Char) => ParsecT s u m [Symbol]
-parseDerivation  = trySepBy (ws' *> parseSymbol) (notFollowedBy (ws' *> parseIdentifier *> ws' *> (string ":")))
-                <|> [] <$ string "eps"
+parseDerivation  = try $ [] <$ string "eps"
+                <|> trySepBy (ws' *> parseSymbol) (notFollowedBy (ws' *> parseIdentifier *> ws' *> (string ":")))
 
 parseSymbol :: (Stream s m Char) => ParsecT s u m Symbol
 parseSymbol  =  NonTerminalSymbol <$> try parseNonTerminal

--- a/src/SyntaxParser.hs
+++ b/src/SyntaxParser.hs
@@ -56,8 +56,8 @@ parseRule = do
   return (Rule name lhs rhs)
 
 parseDerivation :: (Stream s m Char) => ParsecT s u m [Symbol]
-parseDerivation  =  [] <$ string "eps"
-                <|> trySepBy (ws' *> parseSymbol) (notFollowedBy (ws' *> parseIdentifier *> ws' *> (string ":")))
+parseDerivation  = trySepBy (ws' *> parseSymbol) (notFollowedBy (ws' *> parseIdentifier *> ws' *> (string ":")))
+                <|> [] <$ string "eps"
 
 parseSymbol :: (Stream s m Char) => ParsecT s u m Symbol
 parseSymbol  =  NonTerminalSymbol <$> try parseNonTerminal

--- a/src/SyntaxParser.hs
+++ b/src/SyntaxParser.hs
@@ -56,7 +56,7 @@ parseRule = do
   return (Rule name lhs rhs)
 
 parseDerivation :: (Stream s m Char) => ParsecT s u m [Symbol]
-parseDerivation  = try $ [] <$ string "eps"
+parseDerivation  = try ([] <$ string "eps")
                 <|> trySepBy (ws' *> parseSymbol) (notFollowedBy (ws' *> parseIdentifier *> ws' *> (string ":")))
 
 parseSymbol :: (Stream s m Char) => ParsecT s u m Symbol


### PR DESCRIPTION
For example, the syntax definition below causes an error.

```
syntax E (S) {
  Example : S  -> examples
  ExampleDerivations : examples -> examples example
  ExampleDerivation : example -> "example"
}
```

The error is like

```
typelevelLR: "e.syntax" (line 2, column 19):
unexpected "x"
expecting "eps"
CallStack (from HasCallStack):
  error, called at src/Generate.hs:31:22 in typelevelLR-0.1.0.0-7M2UNcQMvFw1r8bPLfq4Us:Generate
```

This is caused by the higher priority of "eps" rule than others.

So by making the priority of "eps" lower than other rules, we can allow rules which start with 'e' character.

I already ensured that the parser with this change can treat such a case without error.

Thank you :)

**Update on 2/10:** Fix bugs caused by recognizing eps as a terminal symbol by using backtracking and confirmed all the tests passed in the container developed in #6. Sorry for my incomplete check. Any additional requests are welcome.